### PR TITLE
Make capybara a dev dep

### DIFF
--- a/scavenger.gemspec
+++ b/scavenger.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 4.2"
   s.add_dependency "nokogiri", "~> 1.7"
-  s.add_dependency "capybara", "~> 2.10"
 
+  s.add_development_dependency "capybara", "~> 2.10"
   s.add_development_dependency "pry", "~> 0.10"
 end


### PR DESCRIPTION
This will help to keep Capybara updatable when this gem is included in a project using Capybara.