### PR TITLE
ignore files starting with '.'

### DIFF
--- a/lib/scavenger/compressor.rb
+++ b/lib/scavenger/compressor.rb
@@ -24,7 +24,8 @@ module Scavenger
 
     def compress_dir
       sheet = Dir.entries(@path)
-                 .select { |f| !File.directory? f }
+                 .select { |f| should_compress? f }
+                 .sort
                  .map { |f| compress_file(File.join(@path, f), f) }
                  .join("")
 
@@ -43,6 +44,11 @@ module Scavenger
     end
 
     private
+
+    def should_compress?(filename)
+      !File.directory?(filename) &&
+        !File.basename(filename).start_with?('.')
+    end
 
     def remove_comments(doc)
       doc.xpath("//comment()").remove


### PR DESCRIPTION
Stops the compressor from choking on meta files like OS X's
'.DS_Store' that may be added without the user's knowledge.

Also sorts the files alphabetically before compression. Apart from
being tidier and more predictable, this stops the test from failing
if the OS doesn't read the files in alphabetical order.