### PR TITLE
Namespace the IDs in the SVG file

### DIFF
--- a/lib/scavenger/compressor.rb
+++ b/lib/scavenger/compressor.rb
@@ -69,7 +69,7 @@ module Scavenger
         attribute.remove unless attribute.name == "viewBox"
       end
       doc.name = "symbol"
-      doc["id"] = id.chomp(".svg")
+      doc["id"] = Scavenger::Config.id_prefix + id.chomp(".svg")
       doc["preserveAspectRatio"] = Scavenger::Config.aspect_ratio
     end
   end

--- a/lib/scavenger/config.rb
+++ b/lib/scavenger/config.rb
@@ -4,9 +4,11 @@ module Scavenger
       attr_accessor :svg_directory
       attr_accessor :sprite_path
       attr_accessor :class_prefix
+      attr_accessor :id_prefix
       attr_accessor :aspect_ratio
     end
 
     self.aspect_ratio = "xMinYMin meet"
+    self.id_prefix = ""
   end
 end

--- a/lib/scavenger/view_helpers.rb
+++ b/lib/scavenger/view_helpers.rb
@@ -10,7 +10,7 @@ module Scavenger
 
     def svg(ref, options = {})
       options[:class] = "#{Scavenger::Config.class_prefix}#{ref}" if options[:class].nil?
-      content_tag :svg, "<use xlink:href=\"##{ref}\"/>".html_safe, options
+      content_tag :svg, "<use xlink:href=\"##{Scavenger::Config.id_prefix}#{ref}\"/>".html_safe, options
     end
 
     def scavenger_sprite_path


### PR DESCRIPTION
Because the generated IDs are global, it would be nice to be able to give them a common prefix so that they don't clash with other IDs in use on the page. Currently, the only way to do this is prefixing the names of all the individual SVGs.

This branch adds a configuration option `id_prefix`, which is prepended to the IDs of generated symbols in the sprite sheet, and automatically inserted into the `use` element when the view helper is used.