### PR TITLE
Upgrade vulnerable Nokogiri version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     nio4r (2.3.1)
-    nokogiri (1.10.2)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     pry (0.12.2)
       coderay (~> 1.1.0)


### PR DESCRIPTION
CVE-2019-5477
Vulnerable versions: < 1.10.4
Patched version: 1.10.4